### PR TITLE
Updated BQSKit.md

### DIFF
--- a/src/projects/BQSKit.md
+++ b/src/projects/BQSKit.md
@@ -1,7 +1,7 @@
 ---
 title: BQSKit
 emoji: 🍪
-project_url: github.com/bqskit
+project_url: github.com/BQSKit/bqskit
 metaDescription: The Berkeley Quantum Synthesis Toolkit (BQSKit) [bis • kit] is a powerful and portable quantum compiler framework.
 date: 2025-04-02
 summary: The Berkeley Quantum Synthesis Toolkit (BQSKit) [bis • kit] is a powerful and portable quantum compiler framework.


### PR DESCRIPTION
Currently The project URL for [BQSKit](https://unitaryhack.dev/projects/bqskit/github.com/bqskit) is redirecting towards a broken link . This PR is made to fix the broken Link 
![BQSKIT](https://github.com/user-attachments/assets/43f45e7d-4741-4069-ba19-fdfdac79076c)
