### PR TITLE
Fix responsive HACKdays table

### DIFF
--- a/src/assets/scss/layouts/home.scss
+++ b/src/assets/scss/layouts/home.scss
@@ -139,3 +139,8 @@
     padding: 8px 20px 9px;
   }
 }
+
+/* Ensure tables scroll on small screens */
+.table-container {
+  overflow-x: auto;
+}

--- a/src/index.njk
+++ b/src/index.njk
@@ -89,6 +89,7 @@ section: home
     <div class="list-header">
       <h2 class="list-header__title">HACKdays</h2>
     </div>
+    <div class="table-container">
     <table>
       <thead>
         <tr>
@@ -140,5 +141,6 @@ section: home
         </tr>
       </tbody>
     </table>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- allow the HACKdays table on the homepage to scroll on small screens
- wrap the table in a new container

fixes https://github.com/unitaryfoundation/unitaryhack/issues/30

I'm not sure what the ideal solution is here since there is such limited horizontal real estate on mobile, but this works for now.

tagging @francespoblete in case you know a better solution.