### PR TITLE
Make exclusion of bounties/leaderboard configurable 

### DIFF
--- a/src/_includes/partials/drawer.njk
+++ b/src/_includes/partials/drawer.njk
@@ -19,7 +19,6 @@
           </a>
         </li>
       {%- for entry in navPages %}
-        {% if entry.title != "Bounties" and entry.title != "Leaderboard" %}
         <li class="drawer__nav-item">
           <a
             href="{{ entry.url | url }}"
@@ -28,7 +27,6 @@
             {{ entry.title }}
           </a>
         </li>
-        {% endif %}
       {%- endfor %}
       </ul>
     </div>

--- a/src/_includes/partials/site-header.njk
+++ b/src/_includes/partials/site-header.njk
@@ -36,7 +36,7 @@
           <li class="site-header__item">
             <button class="site-header__link site-header__link--theme-switch" data-theme-switch>
               {{ global.switch_theme_icon | svg | safe }}
-            </button> 
+            </button>
           </li>
         {% endif %} #}
       </ul>

--- a/src/pages/bounties.md
+++ b/src/pages/bounties.md
@@ -9,4 +9,5 @@ emoji: 💻
 eleventyNavigation:
   order: 4
   key: Bounties
+eleventyExcludeFromCollections: false # set to true to hide in navbars pre-hack
 ---

--- a/src/pages/leaderboard.md
+++ b/src/pages/leaderboard.md
@@ -8,4 +8,5 @@ emoji: 🏆
 eleventyNavigation:
   key: Leaderboard
   order: 4
+eleventyExcludeFromCollections: false # set to true to hide in navbars pre-hack
 ---


### PR DESCRIPTION
Resolves #35 by enabling the bounties and leaderboard links on all pages. The leaderboard link was also disabled, and figured it was ready to share?

Rather than making a single environmental variable, the eleventy [docs](https://www.11ty.dev/docs/collections/#how-to-exclude-content-from-collections) had this variable to set in markdown. Figured that was an ok balance too.