### PR TITLE
fix: broken links for msft qkd and msft qkd chemistry

### DIFF
--- a/src/projects/msft-qdk-chemistry.md
+++ b/src/projects/msft-qdk-chemistry.md
@@ -2,7 +2,7 @@
 title: "MSFT QDK - Chemistry"
 id: "qdk-chemistry: a high-performance toolkit for quantum and classical chemistry calculations."
 emoji: "⚛️ 💻"
-project_url: "microsoft/qdk-chemistry: A high-performance toolkit for quantum and classical chemistry calculations."
+project_url: "https://github.com/microsoft/qdk-chemistry"
 metaDescription: "A high-performance toolkit for quantum and classical chemistry calculations."
 date: 2026-05-12
 summary: "A high-performance toolkit for quantum and classical chemistry calculations."

--- a/src/projects/msft-qdk.md
+++ b/src/projects/msft-qdk.md
@@ -2,7 +2,7 @@
 title: "MSFT QDK"
 id: "qdk: microsoft quantum development kit, including the q"
 emoji: "⚛️ 💻"
-project_url: "microsoft/qdk: Microsoft Quantum Development Kit, including the Q# programming language, resource estimator, and Quantum Katas"
+project_url: "https://github.com/microsoft/qdk"
 metaDescription: "Microsoft Quantum Development Kit, including the Q# programming language, resource estimator, and Quantum Katas"
 date: 2026-05-12
 summary: "Microsoft Quantum Development Kit, including the Q# programming language, resource estimator, and Quantum Katas"


### PR DESCRIPTION
Links for microsoft-qkd and microsoft-qkd-chemistry were broken due to missing github prefix and metaDescription in the `project_url`.