### PR TITLE
Use GitHub app to bypass ruleset

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -7,15 +7,24 @@ on:
     - cron: "0 */2 * * *" # every 2 hours
 
 permissions:
-  contents: write
-  actions: write
+  contents: read
 
 jobs:
   update_data:
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout uhack repo
         uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -29,7 +38,7 @@ jobs:
 
       - name: Scrape GitHub
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           GL_TOKEN: ${{ secrets.GL_TOKEN }}
         run: |
           cd src/_data
@@ -42,18 +51,3 @@ jobs:
           add: "src/_data/*.json"
           message: "🏆 update hackathon results 🏆"
           default_author: github_actions
-
-      - name: Trigger website deploy
-        if: steps.push_data.outputs.committed == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: "buildsite.yaml",
-              ref: "main",
-              inputs: {
-                target: "production",
-              },
-            });


### PR DESCRIPTION
New workflow setup through a GitHub app in order to keep the branch-protection ruleset, but allow the action to update result to bypass that ruleset.
@bachase I believe you had to do something similar with ucc-bench-bot