### PR TITLE
Show multi-year hacker contributions

### DIFF
--- a/src/_data/hackersByYear.js
+++ b/src/_data/hackersByYear.js
@@ -1,0 +1,74 @@
+const hackers2023 = require("./hackers_2023.json");
+const hackers2024 = require("./hackers_2024.json");
+const hackers2026 = require("./hackers.json");
+
+const HACKER_DATA_BY_YEAR = [
+  { year: 2023, hackers: hackers2023 },
+  { year: 2024, hackers: hackers2024 },
+  { year: 2026, hackers: hackers2026 },
+];
+
+function getBounties(hacker) {
+  return Array.isArray(hacker.bounties) ? hacker.bounties : [];
+}
+
+function getTotalValue(hacker) {
+  return Number(hacker.total_value || 0);
+}
+
+module.exports = () => {
+  const hackersByUsername = new Map();
+
+  for (const { year, hackers } of HACKER_DATA_BY_YEAR) {
+    for (const hacker of hackers) {
+      if (!hacker.username) {
+        continue;
+      }
+
+      const usernameKey = hacker.username.toLowerCase();
+      const bounties = getBounties(hacker);
+
+      if (!hackersByUsername.has(usernameKey)) {
+        hackersByUsername.set(usernameKey, {
+          username: hacker.username,
+          total_value: 0,
+          total_bounties: 0,
+          projectNames: new Set(),
+          years: [],
+        });
+      }
+
+      const hackerSummary = hackersByUsername.get(usernameKey);
+      hackerSummary.total_value += getTotalValue(hacker);
+      hackerSummary.total_bounties += bounties.length;
+      hackerSummary.years.push({
+        year,
+        bounties,
+        num_projects: Number(hacker.num_projects || 0),
+        total_value: getTotalValue(hacker),
+      });
+
+      for (const bounty of bounties) {
+        if (bounty.project) {
+          hackerSummary.projectNames.add(bounty.project);
+        }
+      }
+    }
+  }
+
+  return Array.from(hackersByUsername.values())
+    .map((hacker) => {
+      const { projectNames, ...hackerSummary } = hacker;
+      return {
+        ...hackerSummary,
+        num_projects: projectNames.size,
+        years: hackerSummary.years.sort((a, b) => b.year - a.year),
+      };
+    })
+    .sort((a, b) => {
+      if (b.total_value !== a.total_value) {
+        return b.total_value - a.total_value;
+      }
+      return a.username.localeCompare(b.username);
+    });
+};

--- a/src/_data/hackers_2023.json
+++ b/src/_data/hackers_2023.json
@@ -1,0 +1,1184 @@
+[
+  {
+    "username": "stevescia",
+    "bounties": [
+      {
+        "url": "https://github.com/unitaryfund/qrack/issues/988",
+        "title": "Extend QCircuit to QInterface",
+        "project": "qrack",
+        "value": 200
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 200
+  },
+  {
+    "username": "golanor",
+    "bounties": [
+      {
+        "url": "https://github.com/unitaryfund/pyqrack/issues/13",
+        "title": "Unit tests: mirror circuits",
+        "project": "qrack",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/scqubits/scqubits/issues/185",
+        "title": "Adding support for 1/f flux noise channel to the flux qubit class",
+        "project": "scqubits",
+        "value": 100
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 200
+  },
+  {
+    "username": "AVDiv",
+    "bounties": [
+      {
+        "url": "https://github.com/iqm-finland/KQCircuits/issues/48",
+        "title": "Provide Vim command for `create_element_from_path.py`",
+        "project": "kqcircuits",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/unitaryfund/metriq-client/issues/73",
+        "title": "Add examples for results API endpoints",
+        "project": "metriq-app",
+        "value": 75
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 125
+  },
+  {
+    "username": "king-p3nguin",
+    "bounties": [
+      {
+        "url": "https://github.com/Quantomatic/zxlive/issues/3",
+        "title": "Importing and Exporting the diagram",
+        "project": "zxlive",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/Quantomatic/zxlive/issues/6",
+        "title": "Improving the GUI",
+        "project": "zxlive",
+        "value": 225
+      },
+      {
+        "url": "https://github.com/qiskit-community/qiskit-braket-provider/issues/86",
+        "title": "Support for Parametric Circuits",
+        "project": "qiskit-braket-provider",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/Quandela/Perceval/issues/206",
+        "title": "Latex Renderer",
+        "project": "perceval",
+        "value": 150
+      }
+    ],
+    "num_projects": 3,
+    "total_value": 525
+  },
+  {
+    "username": "mark-koch",
+    "bounties": [
+      {
+        "url": "https://github.com/Quantomatic/zxlive/issues/12",
+        "title": "Consistent naming conventions",
+        "project": "zxlive",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/Quantomatic/zxlive/issues/10",
+        "title": "Code organisation",
+        "project": "zxlive",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 175
+  },
+  {
+    "username": "WingCode",
+    "bounties": [
+      {
+        "url": "https://github.com/AgnostiqHQ/covalent/issues/1648",
+        "title": "Determine if covalent subprocess starts successfully",
+        "project": "covalent",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/AgnostiqHQ/covalent-awsbatch-plugin/issues/76",
+        "title": "Support task cancellation",
+        "project": "covalent",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/AgnostiqHQ/covalent-braket-plugin/issues/71",
+        "title": "Support task cancellation",
+        "project": "covalent",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/unitaryfund/metriq-client/issues/71",
+        "title": "Add test suite for examples directory",
+        "project": "metriq-app",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/unitaryfund/metriq-client/issues/72",
+        "title": "Add examples for missing submission endpoints",
+        "project": "metriq-app",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/CQCL/lambeq/issues/84",
+        "title": "UnitaryHACK: Replace unknown words in diagrams with `UNK` token",
+        "project": "lambeq",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/qiskit-community/qiskit-braket-provider/issues/19",
+        "title": "Tests: mock tests for cloud devices",
+        "project": "qiskit-braket-provider",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/qiskit-community/qiskit-braket-provider/issues/91",
+        "title": "Enable (some) transpilation with Braket",
+        "project": "qiskit-braket-provider",
+        "value": 500
+      },
+      {
+        "url": "https://github.com/qiskit-community/qiskit-braket-provider/issues/85",
+        "title": "Reference `OpenQASMDeviceActionProperties` for Braket devices",
+        "project": "qiskit-braket-provider",
+        "value": 30
+      },
+      {
+        "url": "https://github.com/scqubits/scqubits/issues/186",
+        "title": "Adding code documentation",
+        "project": "scqubits",
+        "value": 75
+      }
+    ],
+    "num_projects": 5,
+    "total_value": 1130
+  },
+  {
+    "username": "maxwell04-wq",
+    "bounties": [
+      {
+        "url": "https://github.com/Qiskit/qiskit-terra/issues/9031",
+        "title": "Update plot_gate_map (and related visualization functions) to leverage rustworkx.visualization.graphviz_draw for unknown coupling maps",
+        "project": "qiskit-terra",
+        "value": 150
+      },
+      {
+        "url": "https://github.com/qiskit/qiskit-tutorials/issues/1390",
+        "title": "Update Gradient Framework tutorial to use primitives",
+        "project": "qiskit-terra",
+        "value": 150
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 300
+  },
+  {
+    "username": "ichen17",
+    "bounties": [
+      {
+        "url": "https://github.com/qiskit/qiskit-tutorials/issues/1391",
+        "title": "Add a Variational Quantum Time Evolution Tutorial",
+        "project": "qiskit-terra",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "wenxh0718",
+    "bounties": [
+      {
+        "url": "https://github.com/qiskit/qiskit-tutorials/issues/1391",
+        "title": "Add a Variational Quantum Time Evolution Tutorial",
+        "project": "qiskit-terra",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "huckstar",
+    "bounties": [
+      {
+        "url": "https://github.com/qiskit/qiskit-tutorials/issues/1391",
+        "title": "Add a Variational Quantum Time Evolution Tutorial",
+        "project": "qiskit-terra",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "adilnaut",
+    "bounties": [
+      {
+        "url": "https://github.com/UCL-CCS/symmer/issues/138",
+        "title": "unitaryHACK #2: Optimization of MPO construction",
+        "project": "symmer",
+        "value": 200
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 200
+  },
+  {
+    "username": "devilkiller-ag",
+    "bounties": [
+      {
+        "url": "https://github.com/UCL-CCS/symmer/issues/139",
+        "title": "unitaryHACK #3: Code Documentation",
+        "project": "symmer",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/qiskit-community/qiskit-braket-provider/issues/87",
+        "title": "BraketLocalBackend should display the correct backend name",
+        "project": "qiskit-braket-provider",
+        "value": 25
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 125
+  },
+  {
+    "username": "dakk",
+    "bounties": [
+      {
+        "url": "https://github.com/pasqal-io/Pulser/issues/522",
+        "title": "Adding a function to draw `SequenceSamples`",
+        "project": "pulser",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/pasqal-io/Pulser/issues/501",
+        "title": "Drawing of `Register` goes out of window boundaries",
+        "project": "pulser",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/pasqal-io/Pulser/issues/497",
+        "title": "Add an error when a `Channel` is called with an `eom_config` but without a `modulation bandwidth`",
+        "project": "pulser",
+        "value": 25
+      },
+      {
+        "url": "https://github.com/pasqal-io/Pulser/issues/352",
+        "title": "SPAM errors introduce large simulation overhead ",
+        "project": "pulser",
+        "value": 125
+      },
+      {
+        "url": "https://github.com/aws/amazon-braket-sdk-python/issues/320",
+        "title": "Support for the `run_batch()` method on `LocalSimulator`",
+        "project": "amazon-braket-sdk-python",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/qiskit-community/qiskit-braket-provider/issues/47",
+        "title": "add get_statevector support for BraketLocalBackend",
+        "project": "qiskit-braket-provider",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/qiskit-community/qiskit-braket-provider/issues/37",
+        "title": "Updates for Qiskit to Braket circuit conversion",
+        "project": "qiskit-braket-provider",
+        "value": 25
+      },
+      {
+        "url": "https://github.com/bqskit/bqskit/issues/150",
+        "title": "Non-deterministic circuit iteration for regions",
+        "project": "bqskit",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/Qiskit/qiskit-aer/issues/1632",
+        "title": "Qiskit Aer still uses execute",
+        "project": "qiskit-aer",
+        "value": 80
+      }
+    ],
+    "num_projects": 5,
+    "total_value": 580
+  },
+  {
+    "username": "lumapools",
+    "bounties": [
+      {
+        "url": "https://github.com/entropicalabs/openqaoa/issues/234",
+        "title": "Expose brute force solver through OpenQAOA workflows",
+        "project": "openqaoa",
+        "value": 30
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 30
+  },
+  {
+    "username": "GiacomoFrn",
+    "bounties": [
+      {
+        "url": "https://github.com/entropicalabs/openqaoa/issues/234",
+        "title": "Expose brute force solver through OpenQAOA workflows",
+        "project": "openqaoa",
+        "value": 30
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 30
+  },
+  {
+    "username": "TerraVenil",
+    "bounties": [
+      {
+        "url": "https://github.com/entropicalabs/openqaoa/issues/235",
+        "title": "Add result statistics on measurement outcomes in QAOAResult object",
+        "project": "openqaoa",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/entropicalabs/openqaoa/issues/233",
+        "title": "Prevent double authentication while using `openqaoa-azure`",
+        "project": "openqaoa",
+        "value": 60
+      },
+      {
+        "url": "https://github.com/Qiskit/qiskit-aer/issues/1611",
+        "title": "Some typos in qiskit_aer.AerSimulator docs",
+        "project": "qiskit-aer",
+        "value": 40
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 200
+  },
+  {
+    "username": "AlexisRalli",
+    "bounties": [
+      {
+        "url": "https://github.com/entropicalabs/openqaoa/issues/232",
+        "title": "Implement `as_matrix` method for the `Hamiltonian` class",
+        "project": "openqaoa",
+        "value": 160
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 160
+  },
+  {
+    "username": "Newtech66",
+    "bounties": [
+      {
+        "url": "https://github.com/entropicalabs/openqaoa/issues/226",
+        "title": "Improve test_problems.py",
+        "project": "openqaoa",
+        "value": 120
+      },
+      {
+        "url": "https://github.com/vprusso/toqito/issues/33",
+        "title": "Feature: Is UPB (unextendible product basis)",
+        "project": "toqito",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/PennyLaneAI/pennylane/issues/4121",
+        "title": "Add one_qubit_decomposition function",
+        "project": "pennylane",
+        "value": 75
+      }
+    ],
+    "num_projects": 3,
+    "total_value": 245
+  },
+  {
+    "username": "khnikhil",
+    "bounties": [
+      {
+        "url": "https://github.com/qutip/qutip/issues/2165",
+        "title": "Fermionic creation and annihilation operators",
+        "project": "qutip",
+        "value": 200
+      },
+      {
+        "url": "https://github.com/bqskit/bqskit/issues/153",
+        "title": "Better Qudit Gate Support",
+        "project": "bqskit",
+        "value": 200
+      },
+      {
+        "url": "https://github.com/matt-lourens/hierarqcal/issues/28",
+        "title": "Build simple circuits with strings",
+        "project": "hierarqcal",
+        "value": 200
+      }
+    ],
+    "num_projects": 3,
+    "total_value": 600
+  },
+  {
+    "username": "EmilianoG-byte",
+    "bounties": [
+      {
+        "url": "https://github.com/qutip/qutip/issues/2163",
+        "title": "Add Solver options and list them in API doc",
+        "project": "qutip",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/PennyLaneAI/pennylane/issues/4122",
+        "title": "Support qutrit state preparations",
+        "project": "pennylane",
+        "value": 100
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 150
+  },
+  {
+    "username": "rum1887",
+    "bounties": [
+      {
+        "url": "https://github.com/qutip/qutip-qip/issues/204",
+        "title": "Add qutip-qip tutorials to documentation on Read the docs ",
+        "project": "qutip",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "Gopal-Dahale",
+    "bounties": [
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/136",
+        "title": "add support for more quantum algorithms",
+        "project": "torchquantum",
+        "value": 33
+      },
+      {
+        "url": "https://github.com/CQCL/lambeq/issues/85",
+        "title": "UnitaryHACK: Implement and test gradient free optimizer for circuit models",
+        "project": "lambeq",
+        "value": 150
+      },
+      {
+        "url": "https://github.com/matt-lourens/hierarqcal/issues/29",
+        "title": "Quantum Chemistry example notebook for the exponentiation of Pauli operators",
+        "project": "hierarqcal",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/TeamGraphix/graphix/issues/46",
+        "title": "[demo] Quantum neural network",
+        "project": "graphix",
+        "value": 100
+      }
+    ],
+    "num_projects": 4,
+    "total_value": 383
+  },
+  {
+    "username": "YuNariai",
+    "bounties": [
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/136",
+        "title": "add support for more quantum algorithms",
+        "project": "torchquantum",
+        "value": 33
+      },
+      {
+        "url": "https://github.com/unitaryfund/mitiq/issues/1715",
+        "title": "Improve the cost estimation to run a Calibrator",
+        "project": "mitiq",
+        "value": 100
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 133
+  },
+  {
+    "username": "bopardikarsoham",
+    "bounties": [
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/136",
+        "title": "add support for more quantum algorithms",
+        "project": "torchquantum",
+        "value": 33
+      },
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/134",
+        "title": "add supports for more basic operations and layers",
+        "project": "torchquantum",
+        "value": 33
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 66
+  },
+  {
+    "username": "jinleic",
+    "bounties": [
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/132",
+        "title": "Pulse level simulation and variational circuits",
+        "project": "torchquantum",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "Micheallscarn",
+    "bounties": [
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/133",
+        "title": "support more gradient estimation methods",
+        "project": "torchquantum",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "dtlics",
+    "bounties": [
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/133",
+        "title": "support more gradient estimation methods",
+        "project": "torchquantum",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "pandey-tushar",
+    "bounties": [
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/134",
+        "title": "add supports for more basic operations and layers",
+        "project": "torchquantum",
+        "value": 33
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 33
+  },
+  {
+    "username": "d-bharadwaj",
+    "bounties": [
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/134",
+        "title": "add supports for more basic operations and layers",
+        "project": "torchquantum",
+        "value": 33
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 33
+  },
+  {
+    "username": "denvitko",
+    "bounties": [
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/135",
+        "title": "enhance the documentations and tests",
+        "project": "torchquantum",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "MihirsinhChauhan",
+    "bounties": [
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/135",
+        "title": "enhance the documentations and tests",
+        "project": "torchquantum",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "Aaron-Robertson",
+    "bounties": [
+      {
+        "url": "https://github.com/unitaryfund/metriq-app/issues/269",
+        "title": "Add mathjax support to text input boxes boxes",
+        "project": "metriq-app",
+        "value": 175
+      },
+      {
+        "url": "https://github.com/unitaryfund/mitiq/issues/1377",
+        "title": "Custom package and circuit interface",
+        "project": "mitiq",
+        "value": 100
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 275
+  },
+  {
+    "username": "neiljdo",
+    "bounties": [
+      {
+        "url": "https://github.com/CQCL/lambeq/issues/86",
+        "title": "UnitaryHACK: Serialise ansatz and include in model",
+        "project": "lambeq",
+        "value": 250
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 250
+  },
+  {
+    "username": "ACE07-Sev",
+    "bounties": [
+      {
+        "url": "https://github.com/CQCL/lambeq/issues/84",
+        "title": "UnitaryHACK: Replace unknown words in diagrams with `UNK` token",
+        "project": "lambeq",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "prilcool",
+    "bounties": [
+      {
+        "url": "https://github.com/pasqal-io/PyQ/issues/54",
+        "title": "Write doc strings for most important gates/circuits",
+        "project": "pyq",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "zain2864",
+    "bounties": [
+      {
+        "url": "https://github.com/pasqal-io/PyQ/issues/53",
+        "title": "Unify the three hamiltonian evolution classes into one `HamiltonianEvolution`",
+        "project": "pyq",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "PedroCarreiras",
+    "bounties": [
+      {
+        "url": "https://github.com/pasqal-io/PyQ/issues/36",
+        "title": "Overload the * operator of modules.RotationsGate to allow for gate composition",
+        "project": "pyq",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "andre-a-alves",
+    "bounties": [
+      {
+        "url": "https://github.com/unitaryfund/mitiq/issues/1835",
+        "title": "Make mitiq compatible with latest version of Qiskit",
+        "project": "mitiq",
+        "value": 80
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 80
+  },
+  {
+    "username": "georgios-ts",
+    "bounties": [
+      {
+        "url": "https://github.com/vprusso/toqito/issues/144",
+        "title": "Question/Bug: Not able to apply channel correctly",
+        "project": "toqito",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "ErikQQY",
+    "bounties": [
+      {
+        "url": "https://github.com/vprusso/toqito/issues/145",
+        "title": "Refactor: Partial trace and partial transpose",
+        "project": "toqito",
+        "value": 75
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 75
+  },
+  {
+    "username": "purva-thakre",
+    "bounties": [
+      {
+        "url": "https://github.com/vprusso/toqito/issues/141",
+        "title": "Feature: Fidelity of separability",
+        "project": "toqito",
+        "value": 75
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 75
+  },
+  {
+    "username": "smtsjhr",
+    "bounties": [
+      {
+        "url": "https://github.com/vprusso/toqito/issues/33",
+        "title": "Feature: Is UPB (unextendible product basis)",
+        "project": "toqito",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "ryanprior",
+    "bounties": [
+      {
+        "url": "https://github.com/vprusso/toqito/issues/146",
+        "title": "CI/CD: Setup automated lint + build system",
+        "project": "toqito",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "AmanieOxana",
+    "bounties": [
+      {
+        "url": "https://github.com/vprusso/toqito/issues/148",
+        "title": "Feature: Completely bounded trace norm",
+        "project": "toqito",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "Amana-L",
+    "bounties": [
+      {
+        "url": "https://github.com/QuEraComputing/Bloqade.jl/issues/517",
+        "title": "[DOC] More examples for `BloqadeLattices` docstrings",
+        "project": "bloqade.jl",
+        "value": 25
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 25
+  },
+  {
+    "username": "manulpatel",
+    "bounties": [
+      {
+        "url": "https://github.com/QuEraComputing/Bloqade.jl/issues/375",
+        "title": "[Feature Request] CompatHelper",
+        "project": "bloqade.jl",
+        "value": 25
+      },
+      {
+        "url": "https://github.com/PennyLaneAI/pennylane/issues/4123",
+        "title": "Update plugins in Docker builds",
+        "project": "pennylane",
+        "value": 25
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 50
+  },
+  {
+    "username": "mmlouamri",
+    "bounties": [
+      {
+        "url": "https://github.com/qBraid/qBraid/issues/233",
+        "title": "Braket circuit compilation method for `AwsDeviceWrapper.run`",
+        "project": "qbraid",
+        "value": 150
+      },
+      {
+        "url": "https://github.com/qBraid/qBraid/issues/234",
+        "title": "Transpiler gate coverage benchmarking",
+        "project": "qbraid",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 250
+  },
+  {
+    "username": "TheGupta2012",
+    "bounties": [
+      {
+        "url": "https://github.com/qBraid/qBraid/issues/223",
+        "title": "OpenQASM 2.0 --> OpenQASM 3.0 conversion function",
+        "project": "qbraid",
+        "value": 125
+      },
+      {
+        "url": "https://github.com/qBraid/qBraid/issues/231",
+        "title": "Implement `IBMBackendWrapper.run_batch` method",
+        "project": "qbraid",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 175
+  },
+  {
+    "username": "CalebMcIrvinGitHub",
+    "bounties": [
+      {
+        "url": "https://github.com/qBraid/qBraid/issues/227",
+        "title": "OpenQASM 3.0 circuit drawer",
+        "project": "qbraid",
+        "value": 75
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 75
+  },
+  {
+    "username": "robotAstray",
+    "bounties": [
+      {
+        "url": "https://github.com/qiskit-community/qiskit-braket-provider/issues/45",
+        "title": "Rename AWSBraketJob to AmazonBraketTask",
+        "project": "qiskit-braket-provider",
+        "value": 30
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 30
+  },
+  {
+    "username": "urihan",
+    "bounties": [
+      {
+        "url": "https://github.com/qiskit-community/qiskit-braket-provider/issues/37",
+        "title": "Updates for Qiskit to Braket circuit conversion",
+        "project": "qiskit-braket-provider",
+        "value": 25
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 25
+  },
+  {
+    "username": "Gmontes01",
+    "bounties": [
+      {
+        "url": "https://github.com/qiskit-community/qiskit-braket-provider/issues/90",
+        "title": "Gate decomposition",
+        "project": "qiskit-braket-provider",
+        "value": 500
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 500
+  },
+  {
+    "username": "san-gh",
+    "bounties": [
+      {
+        "url": "https://github.com/tqsd/QuNetSim/issues/145",
+        "title": "Add a variation of \"get_classical\" that can receive a message from any host",
+        "project": "qunetsim",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "atomgardner",
+    "bounties": [
+      {
+        "url": "https://github.com/tqsd/QuNetSim/issues/131",
+        "title": "Implement a simulation for MDI-QKD",
+        "project": "qunetsim",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "JiQing000",
+    "bounties": [
+      {
+        "url": "https://github.com/abdullahkhalids/qecft/issues/1",
+        "title": "Implementation of surface codes",
+        "project": "qecft",
+        "value": 75
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 75
+  },
+  {
+    "username": "victor-onofre",
+    "bounties": [
+      {
+        "url": "https://github.com/abdullahkhalids/qecft/issues/3",
+        "title": " Implementation of color codes",
+        "project": "qecft",
+        "value": 75
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 75
+  },
+  {
+    "username": "schance995",
+    "bounties": [
+      {
+        "url": "https://github.com/abdullahkhalids/qecft/issues/4",
+        "title": "Script to convert book to pdf",
+        "project": "qecft",
+        "value": 125
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 125
+  },
+  {
+    "username": "AnsahMohammad",
+    "bounties": [
+      {
+        "url": "https://github.com/abdullahkhalids/qecft/issues/2",
+        "title": "Forum for solutions",
+        "project": "qecft",
+        "value": 225
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 225
+  },
+  {
+    "username": "metalcyanide",
+    "bounties": [
+      {
+        "url": "https://github.com/matt-lourens/hierarqcal/issues/27",
+        "title": "Add functionality to visualise hypergraphs (N-ary edges for digraphs)",
+        "project": "hierarqcal",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "anushkrishnav",
+    "bounties": [
+      {
+        "url": "https://github.com/PennyLaneAI/pennylane/issues/4088",
+        "title": "Provide an informative string representation for ParametrizedHamiltonian",
+        "project": "pennylane",
+        "value": 150
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 150
+  },
+  {
+    "username": "tnemoz",
+    "bounties": [
+      {
+        "url": "https://github.com/PennyLaneAI/pennylane/issues/4098",
+        "title": "Add support for calculating the trace distance",
+        "project": "pennylane",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "ejthomas",
+    "bounties": [
+      {
+        "url": "https://github.com/PennyLaneAI/pennylane/issues/4055",
+        "title": "[BUG] Operations in `has_unitary_generator` do not really have unitary generators",
+        "project": "pennylane",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "KevinJoven11",
+    "bounties": [
+      {
+        "url": "https://github.com/scqubits/scqubits/issues/184",
+        "title": "Short tutorial video on using scqubits",
+        "project": "scqubits",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "Algh89110377",
+    "bounties": [
+      {
+        "url": "https://github.com/scqubits/scqubits/issues/184",
+        "title": "Short tutorial video on using scqubits",
+        "project": "scqubits",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "teng10",
+    "bounties": [
+      {
+        "url": "https://github.com/hongyehu/PyClifford/issues/15",
+        "title": "[UnitaryHack] Implementing state expectation in parallel for a given batch of stabilizer states",
+        "project": "pyclifford",
+        "value": 150
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 150
+  },
+  {
+    "username": "AngeloDanducci",
+    "bounties": [
+      {
+        "url": "https://github.com/Qiskit/qiskit-aer/issues/1805",
+        "title": "Remove `PulseSimulator`",
+        "project": "qiskit-aer",
+        "value": 180
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 180
+  },
+  {
+    "username": "tungbq",
+    "bounties": [
+      {
+        "url": "https://github.com/Qiskit/qiskit-aer/issues/1807",
+        "title": "Remove Python 3.7 from Github actions",
+        "project": "qiskit-aer",
+        "value": 80
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 80
+  },
+  {
+    "username": "davidlearn",
+    "bounties": [
+      {
+        "url": "https://github.com/Qiskit/qiskit-aer/issues/1806",
+        "title": "Renew example codes in README",
+        "project": "qiskit-aer",
+        "value": 80
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 80
+  },
+  {
+    "username": "Innanov",
+    "bounties": [
+      {
+        "url": "https://github.com/Qiskit/qiskit-aer/issues/1611",
+        "title": "Some typos in qiskit_aer.AerSimulator docs",
+        "project": "qiskit-aer",
+        "value": 40
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 40
+  },
+  {
+    "username": "JMaterne",
+    "bounties": [
+      {
+        "url": "https://github.com/Quandela/Perceval/issues/208",
+        "title": "Definition of (perfect) complex input states",
+        "project": "perceval",
+        "value": 200
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 200
+  },
+  {
+    "username": "Sri-Harsha-T",
+    "bounties": [
+      {
+        "url": "https://github.com/errorcorrectionzoo/eczoo_data/issues/296",
+        "title": "Generate all ancestors of a given code",
+        "project": "eczoo_data",
+        "value": 200
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 200
+  },
+  {
+    "username": "kvathupo",
+    "bounties": [
+      {
+        "url": "https://github.com/errorcorrectionzoo/eczoo_data/issues/47",
+        "title": "Find unlinked code names and attach links to them",
+        "project": "eczoo_data",
+        "value": 200
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 200
+  }
+]

--- a/src/_data/hackers_2024.json
+++ b/src/_data/hackers_2024.json
@@ -1,0 +1,1342 @@
+[
+  {
+    "username": "nirajvenkat",
+    "bounties": [
+      {
+        "url": "https://github.com/microsoft/qsharp/issues/1063",
+        "title": "Add ability to save the Resource Estimator space-time diagram as a file (png/jpg/svg)",
+        "project": "qsharp",
+        "value": 60
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 60
+  },
+  {
+    "username": "Manvi-Agrawal",
+    "bounties": [
+      {
+        "url": "https://github.com/microsoft/qsharp/issues/1212",
+        "title": "Add three qubit `AND` operation to public API",
+        "project": "qsharp",
+        "value": 70
+      },
+      {
+        "url": "https://github.com/microsoft/qsharp/issues/1471",
+        "title": "Lint rule: `operation`s that don't manipulate quantum state can be `function`s instead",
+        "project": "qsharp",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/QuEraComputing/bloqade-python/issues/987",
+        "title": "unitaryhack tracking issue by Manvi-Agrawal",
+        "project": "bloqade-python",
+        "value": 72
+      },
+      {
+        "url": "https://github.com/amazon-braket/amazon-braket-sdk-python/issues/974",
+        "title": "Support for adding barriers and delays to `Circuit`",
+        "project": "amazon-braket-sdk-python",
+        "value": 130
+      }
+    ],
+    "num_projects": 3,
+    "total_value": 372
+  },
+  {
+    "username": "Fe-r-oz",
+    "bounties": [
+      {
+        "url": "https://github.com/aarontrowbridge/QuantumCollocation.jl/issues/102",
+        "title": "[Feature]: quantum utils docstrings and tests",
+        "project": "piccolo.jl",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/aarontrowbridge/QuantumCollocation.jl/issues/89",
+        "title": "[Feature]: Sampling-based robust control",
+        "project": "piccolo.jl",
+        "value": 150
+      },
+      {
+        "url": "https://github.com/amazon-braket/Braket.jl/issues/79",
+        "title": "Full support for local detuning",
+        "project": "braket.jl",
+        "value": 70
+      },
+      {
+        "url": "https://github.com/amazon-braket/Braket.jl/issues/80",
+        "title": "Support for Braket Direct reservations",
+        "project": "braket.jl",
+        "value": 120
+      },
+      {
+        "url": "https://github.com/amazon-braket/Braket.jl/issues/82",
+        "title": "Support for symbolic expressions in FreeParameters",
+        "project": "braket.jl",
+        "value": 70
+      },
+      {
+        "url": "https://github.com/amazon-braket/BraketSimulator.jl/issues/14",
+        "title": "Expanded support for quantum chemistry operations",
+        "project": "braketsimulator.jl",
+        "value": 80
+      }
+    ],
+    "num_projects": 3,
+    "total_value": 540
+  },
+  {
+    "username": "maxwell04-wq",
+    "bounties": [
+      {
+        "url": "https://github.com/aarontrowbridge/QuantumCollocation.jl/issues/85",
+        "title": "[Feature]: interface with QuantumOptics.jl",
+        "project": "piccolo.jl",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/Qiskit/rustworkx/issues/774",
+        "title": "`mpl_draw()` does not work for multigraphs",
+        "project": "rustworkx",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/Quandela/Perceval/issues/399",
+        "title": "QASM to linear optics circuit converter",
+        "project": "perceval",
+        "value": 100
+      }
+    ],
+    "num_projects": 3,
+    "total_value": 225
+  },
+  {
+    "username": "ErikQQY",
+    "bounties": [
+      {
+        "url": "https://github.com/aarontrowbridge/NamedTrajectories.jl/issues/37",
+        "title": "[Feature]: Global Trajectory Parameters",
+        "project": "piccolo.jl",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/aarontrowbridge/NamedTrajectories.jl/issues/39",
+        "title": "[Feature]: docstrings for NamedTrajectory struct and consttructors",
+        "project": "piccolo.jl",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 150
+  },
+  {
+    "username": "0mWh",
+    "bounties": [
+      {
+        "url": "https://github.com/dorahacksglobal/qc-classifier/issues/1",
+        "title": "QRNG Classifier Preprocessing Functions Improvements",
+        "project": "qc-classifier",
+        "value": 75
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 75
+  },
+  {
+    "username": "schance995",
+    "bounties": [
+      {
+        "url": "https://github.com/dorahacksglobal/qc-classifier/issues/1",
+        "title": "QRNG Classifier Preprocessing Functions Improvements",
+        "project": "qc-classifier",
+        "value": 75
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 75
+  },
+  {
+    "username": "idriss-hamadi",
+    "bounties": [
+      {
+        "url": "https://github.com/dorahacksglobal/qc-classifier/issues/3",
+        "title": "QNRG Classifier ML Model Improvements",
+        "project": "qc-classifier",
+        "value": 150
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 150
+  },
+  {
+    "username": "AbdullahKazi500",
+    "bounties": [
+      {
+        "url": "https://github.com/dorahacksglobal/qc-classifier/issues/2",
+        "title": "Classification Model for General Quantum Circuits",
+        "project": "qc-classifier",
+        "value": 200
+      },
+      {
+        "url": "https://github.com/iqm-finland/KQCircuits/issues/90",
+        "title": "Macro to open a tutorial layout",
+        "project": "kqcircuits",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/260",
+        "title": "Enhance the Pulse-Level Simulation",
+        "project": "torchquantum",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/264",
+        "title": "Adding new examples and algorithms for TQ",
+        "project": "torchquantum",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/tencent-quantum-lab/tensorcircuit/issues/211",
+        "title": "Stabilizer simulation example utilizing stim backend",
+        "project": "tensorcircuit",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/TeamGraphix/graphix/issues/136",
+        "title": "Application of tensor-network MBQC simulation",
+        "project": "graphix",
+        "value": 55
+      }
+    ],
+    "num_projects": 5,
+    "total_value": 555
+  },
+  {
+    "username": "rodolfocarobene",
+    "bounties": [
+      {
+        "url": "https://github.com/quantumlib/Cirq/issues/5715",
+        "title": "`Xa*Zb*Zb*Zb` works but `Xa*Zb**3` raises error ",
+        "project": "cirq",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/entropicalabs/openqaoa/issues/307",
+        "title": "Update the package to support `python >=3.11`",
+        "project": "openqaoa",
+        "value": 70
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 170
+  },
+  {
+    "username": "Yash-10",
+    "bounties": [
+      {
+        "url": "https://github.com/quantumlib/Cirq/issues/4691",
+        "title": "Add an option to highlight a subset of qubits in cirq.Heatmap ",
+        "project": "cirq",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/pasqal-io/qadence/issues/214",
+        "title": "[Feature] Add checkpoint_best_only in train_grad",
+        "project": "qadence",
+        "value": 150
+      },
+      {
+        "url": "https://github.com/amazon-braket/autoqasm/issues/13",
+        "title": "Automatically determine dimensions for `aq.ArrayVar` declaration",
+        "project": "autoqasm",
+        "value": 40
+      },
+      {
+        "url": "https://github.com/vprusso/toqito/issues/518",
+        "title": "Checks for `is_separable` are not complete",
+        "project": "toqito",
+        "value": 80
+      },
+      {
+        "url": "https://github.com/scqubits/scqubits/issues/220",
+        "title": "Addition of tests for the custom diagonalization functionality. ",
+        "project": "scqubits",
+        "value": 100
+      }
+    ],
+    "num_projects": 5,
+    "total_value": 470
+  },
+  {
+    "username": "tomv42",
+    "bounties": [
+      {
+        "url": "https://github.com/dakk/qlasskit/issues/26",
+        "title": "py2qasm cli tool",
+        "project": "qlasskit",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/dakk/qlasskit/issues/28",
+        "title": "py2bexp bool expressions exporter",
+        "project": "qlasskit",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/dakk/qlasskit/issues/23",
+        "title": "Pow operator",
+        "project": "qlasskit",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 250
+  },
+  {
+    "username": "divshacker",
+    "bounties": [
+      {
+        "url": "https://github.com/dakk/qlasskit/issues/32",
+        "title": "Request for algorithms!",
+        "project": "qlasskit",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/Qiskit/qiskit-aer/issues/2114",
+        "title": "Update documents and tutorials",
+        "project": "qiskit-aer",
+        "value": 60
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 135
+  },
+  {
+    "username": "anushkrishnav",
+    "bounties": [
+      {
+        "url": "https://github.com/goodchemistryco/Tangelo/issues/383",
+        "title": "Incompatibility with PySCF >= 2.5.0",
+        "project": "tangelo",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/goodchemistryco/Tangelo/issues/388",
+        "title": "[BUG] `Circuit.draw()` returns an error when gate parameter is a string",
+        "project": "tangelo",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/qutip/qutip/issues/2400",
+        "title": "Bug in the rendering of the process matrix",
+        "project": "qutip-tutorials",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/Qiskit/rustworkx/issues/750",
+        "title": "graphviz draw tooltip with special characters",
+        "project": "rustworkx",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/vprusso/toqito/issues/168",
+        "title": "Refactor: Permute systems index offset",
+        "project": "toqito",
+        "value": 80
+      },
+      {
+        "url": "https://github.com/scqubits/scqubits/issues/219",
+        "title": "Enhancement of the `plot_transitions()` method",
+        "project": "scqubits",
+        "value": 75
+      }
+    ],
+    "num_projects": 5,
+    "total_value": 480
+  },
+  {
+    "username": "cburdine",
+    "bounties": [
+      {
+        "url": "https://github.com/goodchemistryco/Tangelo/issues/384",
+        "title": "Circuit as reference state in the ansatz definition",
+        "project": "tangelo",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/goodchemistryco/Tangelo/issues/386",
+        "title": "Augment the Rotosolve optimizer to support Rotoselect",
+        "project": "tangelo",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 200
+  },
+  {
+    "username": "king-p3nguin",
+    "bounties": [
+      {
+        "url": "https://github.com/goodchemistryco/Tangelo/issues/385",
+        "title": "Automatic documentation deployment",
+        "project": "tangelo",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/issues/195",
+        "title": "Support `qml.counts` for circuits",
+        "project": "amazon-braket-pennylane-plugin-python",
+        "value": 70
+      },
+      {
+        "url": "https://github.com/pasqal-io/qadence/issues/268",
+        "title": "[Refactor] Better use of projectors",
+        "project": "qadence",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/262",
+        "title": "Make TQ Compatible with Qiskit \u22651.0.0",
+        "project": "torchquantum",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/263",
+        "title": "Supporting Additional Features for tq2qiskit and qiskit2tq",
+        "project": "torchquantum",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/unitaryfund/mitiq/issues/2161",
+        "title": "Test circuit conversion time for large non-cirq circuits",
+        "project": "mitiq",
+        "value": 70
+      },
+      {
+        "url": "https://github.com/amazon-braket/amazon-braket-sdk-python/issues/971",
+        "title": "from_ir method for AnalogHamiltonianSimulation",
+        "project": "amazon-braket-sdk-python",
+        "value": 60
+      },
+      {
+        "url": "https://github.com/tencent-quantum-lab/tensorcircuit/issues/212",
+        "title": "Add examples benchmarking different contractor settings provided by cotengra",
+        "project": "tensorcircuit",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/tencent-quantum-lab/tensorcircuit/issues/211",
+        "title": "Stabilizer simulation example utilizing stim backend",
+        "project": "tensorcircuit",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/tencent-quantum-lab/tensorcircuit/issues/161",
+        "title": "Backend agnostic implementation of quantum Hamiltonian generation",
+        "project": "tensorcircuit",
+        "value": 150
+      },
+      {
+        "url": "https://github.com/PennyLaneAI/pennylane/issues/5647",
+        "title": "Support native measurement-based snapshots in Default Clifford",
+        "project": "pennylane",
+        "value": 125
+      },
+      {
+        "url": "https://github.com/qBraid/qBraid/issues/618",
+        "title": "NetworkX Out, Rustworkx In: Unleash the Speed",
+        "project": "qbraid",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/qBraid/qBraid/issues/624",
+        "title": "Implement tests for IonQ runtime provider",
+        "project": "qbraid",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/qBraid/qBraid/issues/625",
+        "title": "Expand IonQ provider runtime to supported gates",
+        "project": "qbraid",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/qBraid/qbraid-qir/issues/78",
+        "title": "Support for aliases for openqasm3 to qir",
+        "project": "qbraid-qir",
+        "value": 75
+      }
+    ],
+    "num_projects": 10,
+    "total_value": 1300
+  },
+  {
+    "username": "golanor",
+    "bounties": [
+      {
+        "url": "https://github.com/goodchemistryco/Tangelo/issues/387",
+        "title": "Support for multi-controlled rotation (RX, RY, RZ) gates for qiskit backend",
+        "project": "tangelo",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/unitaryfund/pyqrack/issues/23",
+        "title": "CI publishing pipeline",
+        "project": "qrack",
+        "value": 125
+      },
+      {
+        "url": "https://github.com/vprusso/toqito/issues/431",
+        "title": "Ensure PSD operators are being optimized over proper space",
+        "project": "toqito",
+        "value": 80
+      }
+    ],
+    "num_projects": 3,
+    "total_value": 255
+  },
+  {
+    "username": "WingCode",
+    "bounties": [
+      {
+        "url": "https://github.com/qiskit-community/qiskit-braket-provider/issues/177",
+        "title": "Improve unit test coverage to 100%",
+        "project": "qiskit-braket-provider",
+        "value": 200
+      },
+      {
+        "url": "https://github.com/QuEraComputing/bloqade-python/issues/741",
+        "title": "Improve documentation on Batch tasks. ",
+        "project": "bloqade-python",
+        "value": 20
+      },
+      {
+        "url": "https://github.com/amazon-braket/Braket.jl/issues/18",
+        "title": "Feature request: support for loading pickled results from Hybrid Jobs",
+        "project": "braket.jl",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/issues/255",
+        "title": "Print noisy circuit when a Braket noise model is applied to PL device with `parallel=True`",
+        "project": "amazon-braket-pennylane-plugin-python",
+        "value": 90
+      },
+      {
+        "url": "https://github.com/NVIDIA/cuda-quantum/issues/1624",
+        "title": "Organize Documentation Examples ",
+        "project": "cuda-quantum",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/unitaryfund/metriq-app/issues/880",
+        "title": "Prepopulate result dates in \"Add Submission\" workflow",
+        "project": "metriq-app",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/unitaryfund/metriq-app/issues/851",
+        "title": "Metriq freezes from mobile browser",
+        "project": "metriq-app",
+        "value": 150
+      },
+      {
+        "url": "https://github.com/amazon-braket/amazon-braket-default-simulator-python/issues/252",
+        "title": "Support non-contiguous qubit indices",
+        "project": "amazon-braket-default-simulator-python",
+        "value": 100
+      }
+    ],
+    "num_projects": 7,
+    "total_value": 760
+  },
+  {
+    "username": "jpacold",
+    "bounties": [
+      {
+        "url": "https://github.com/unitaryfund/qrack/issues/876",
+        "title": "Extend `ZMask()` to `PhaseRootNMask()`",
+        "project": "qrack",
+        "value": 125
+      },
+      {
+        "url": "https://github.com/Qiskit/rustworkx/issues/803",
+        "title": "Add support to `hexagonal_lattice_graph` for periodcity and position coordinates",
+        "project": "rustworkx",
+        "value": 200
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 325
+  },
+  {
+    "username": "rmoretti9",
+    "bounties": [
+      {
+        "url": "https://github.com/iqm-finland/KQCircuits/issues/91",
+        "title": "Validate and report misconfigured simulation export",
+        "project": "kqcircuits",
+        "value": 75
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 75
+  },
+  {
+    "username": "PietroCampana",
+    "bounties": [
+      {
+        "url": "https://github.com/iqm-finland/KQCircuits/issues/89",
+        "title": "Reload Libraries macro issues: doesn't restore PCells on error, and fails for non-KQC PCells",
+        "project": "kqcircuits",
+        "value": 75
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 75
+  },
+  {
+    "username": "f-martini",
+    "bounties": [
+      {
+        "url": "https://github.com/iqm-finland/KQCircuits/issues/92",
+        "title": "Broken `Edit on Github` link for API pages of KQC documentation",
+        "project": "kqcircuits",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "marcogobbo",
+    "bounties": [
+      {
+        "url": "https://github.com/qutip/qutip-tutorials/issues/93",
+        "title": "Port \"Steady-State: Time-dependent (periodic) quantum system\" tutorial to QuTiP 5.",
+        "project": "qutip-tutorials",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "obliviateandsurrender",
+    "bounties": [
+      {
+        "url": "https://github.com/qutip/qutip-tutorials/issues/92",
+        "title": " Port \"Steady-State: Optomechanical System in the Single-Photon Strong-Coupling Regime\" tutorial to QuTiP 5.",
+        "project": "qutip-tutorials",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "ArturDomingues",
+    "bounties": [
+      {
+        "url": "https://github.com/qutip/qutip-tutorials/issues/91",
+        "title": "Port \"Steady-State: Homodyned Jaynes-Cummings emission\" tutorial to QuTiP 5.",
+        "project": "qutip-tutorials",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "alan-nala",
+    "bounties": [
+      {
+        "url": "https://github.com/qutip/qutip/issues/2389",
+        "title": "Gates in qutip-qutip",
+        "project": "qutip-tutorials",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "atomgardner",
+    "bounties": [
+      {
+        "url": "https://github.com/Qiskit/openqasm3_parser/issues/163",
+        "title": "Refactor lowering list of qubits (gate operands) in syntax_to_semantics.rs",
+        "project": "openqasm3_parser",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/Qiskit/openqasm3_parser/issues/195",
+        "title": "Reduce prefix expression with unary minus wrapping literal, to literal with negative value",
+        "project": "openqasm3_parser",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/yuewuo/fusion-blossom/issues/36",
+        "title": "Rust programming: fix build error in latest rust compiler",
+        "project": "fusion-blossom",
+        "value": 50
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 250
+  },
+  {
+    "username": "abhamra",
+    "bounties": [
+      {
+        "url": "https://github.com/Qiskit/openqasm3_parser/issues/170",
+        "title": "Implement function `from_designator` in syntax_to_semantics.rs",
+        "project": "openqasm3_parser",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "YangLiuWillow",
+    "bounties": [
+      {
+        "url": "https://github.com/yuewuo/fusion-blossom/issues/34",
+        "title": "documentation of configuring parallel parameters",
+        "project": "fusion-blossom",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "ljcamargo",
+    "bounties": [
+      {
+        "url": "https://github.com/Qiskit/qiskit/issues/12067",
+        "title": "Spellcheck API docs (Unity Fund Hackathon) ",
+        "project": "qiskit",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/unitaryfund/metriq-app/issues/878",
+        "title": "Include markdown rendering on homepage",
+        "project": "metriq-app",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/qosf/qosf.org/issues/94",
+        "title": "Create an initial framework for an Autograder for the monthly challenges. ",
+        "project": "qosf.org",
+        "value": 80
+      }
+    ],
+    "num_projects": 3,
+    "total_value": 280
+  },
+  {
+    "username": "shravanpatel30",
+    "bounties": [
+      {
+        "url": "https://github.com/Qiskit/qiskit/issues/12059",
+        "title": "Controlling the Insertion of Multi-Qubit Gates in the Generation of Random Circuits",
+        "project": "qiskit",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "MozammilQ",
+    "bounties": [
+      {
+        "url": "https://github.com/Qiskit/qiskit/issues/12364",
+        "title": "Generation of Random Circuits with Pre-Defined Inter-Qubit Connectivity",
+        "project": "qiskit",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "jyotiraj-code",
+    "bounties": [
+      {
+        "url": "https://github.com/Classiq/classiq-library/issues/28",
+        "title": "Classiq Basics: Quantum Entanglement",
+        "project": "classiq-library",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/Classiq/classiq-library/issues/34",
+        "title": "Create a basic tutorial for running a VQE primitive with Classiq",
+        "project": "classiq-library",
+        "value": 120
+      },
+      {
+        "url": "https://github.com/Classiq/classiq-library/issues/36",
+        "title": "Add initial conditions to the arithmetic example in the arithmetic_expressions notebook",
+        "project": "classiq-library",
+        "value": 80
+      },
+      {
+        "url": "https://github.com/scqubits/scqubits/issues/218",
+        "title": "Short tutorial video on using scqubits",
+        "project": "scqubits",
+        "value": 150
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 400
+  },
+  {
+    "username": "Qubit1718",
+    "bounties": [
+      {
+        "url": "https://github.com/Classiq/classiq-library/issues/41",
+        "title": "Add examples and insights that demonstrates Classiq's HW-aware synthesis capability ",
+        "project": "classiq-library",
+        "value": 150
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 150
+  },
+  {
+    "username": "shubhusion",
+    "bounties": [
+      {
+        "url": "https://github.com/QuEraComputing/bloqade-python/issues/986",
+        "title": "unitaryhack tracking issue for @shubhusion",
+        "project": "bloqade-python",
+        "value": 40
+      },
+      {
+        "url": "https://github.com/Quantum-Universal-Education/Quantum-Universal-Education.github.io/issues/20",
+        "title": "Quantum Applications [unitaryhack]",
+        "project": "quantum-universal-education.github.io",
+        "value": 50
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 90
+  },
+  {
+    "username": "qmanning4",
+    "bounties": [
+      {
+        "url": "https://github.com/QuEraComputing/bloqade-python/issues/988",
+        "title": "unitary hack tracking issue for qmanning4",
+        "project": "bloqade-python",
+        "value": 20
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 20
+  },
+  {
+    "username": "SaashaJoshi",
+    "bounties": [
+      {
+        "url": "https://github.com/pasqal-io/qadence/issues/370",
+        "title": "[Enhance] Add 'backend' argument to product_state",
+        "project": "qadence",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/261",
+        "title": "Develop the TorchQuantum Testing Suite",
+        "project": "torchquantum",
+        "value": 100
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 200
+  },
+  {
+    "username": "neogyk",
+    "bounties": [
+      {
+        "url": "https://github.com/pasqal-io/qadence/issues/368",
+        "title": "[Refactoring]\u00a0Avoid calling block to tensor on diagonal Hamiltonians",
+        "project": "qadence",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "ducthanh1991",
+    "bounties": [
+      {
+        "url": "https://github.com/pasqal-io/qadence/issues/40",
+        "title": "[Performance] Expand PyQComposedBlock to 2 qubit gates",
+        "project": "qadence",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "abidart",
+    "bounties": [
+      {
+        "url": "https://github.com/amazon-braket/autoqasm/issues/9",
+        "title": "Support integer division with `//` operator",
+        "project": "autoqasm",
+        "value": 25
+      },
+      {
+        "url": "https://github.com/amazon-braket/autoqasm/issues/10",
+        "title": "Support arithmetic on measurement results",
+        "project": "autoqasm",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 75
+  },
+  {
+    "username": "daredevil3435",
+    "bounties": [
+      {
+        "url": "https://github.com/amazon-braket/autoqasm/issues/9",
+        "title": "Support integer division with `//` operator",
+        "project": "autoqasm",
+        "value": 25
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 25
+  },
+  {
+    "username": "atharva-satpute",
+    "bounties": [
+      {
+        "url": "https://github.com/amazon-braket/autoqasm/issues/11",
+        "title": "kwargs are not supported when calling an AutoQASM subroutine",
+        "project": "autoqasm",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/amazon-braket/autoqasm/issues/12",
+        "title": "AutoQASM program transpilation should mangle OpenQASM reserved keywords (if they're not Python keywords)",
+        "project": "autoqasm",
+        "value": 60
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 110
+  },
+  {
+    "username": "prakharb10",
+    "bounties": [
+      {
+        "url": "https://github.com/entropicalabs/openqaoa/issues/304",
+        "title": "Update `openqaoa-qiskit` to Qiskit 1.0",
+        "project": "openqaoa",
+        "value": 120
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 120
+  },
+  {
+    "username": "Gopal-Dahale",
+    "bounties": [
+      {
+        "url": "https://github.com/mit-han-lab/torchquantum/issues/264",
+        "title": "Adding new examples and algorithms for TQ",
+        "project": "torchquantum",
+        "value": 50
+      },
+      {
+        "url": "https://github.com/NVIDIA/cuda-quantum/issues/1642",
+        "title": "Readout Error Mitigation",
+        "project": "cuda-quantum",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/tencent-quantum-lab/tensorcircuit/issues/73",
+        "title": "SPSA optimization example",
+        "project": "tensorcircuit",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/matt-lourens/hierarqcal/issues/48",
+        "title": "UnitaryHack Bounty - Quantum Machine Learning Tutorial: Music Genre Classification using HierarQcal",
+        "project": "hierarqcal",
+        "value": 200
+      },
+      {
+        "url": "https://github.com/matt-lourens/hierarqcal/issues/50",
+        "title": "UnitaryHack Bounty - Research and Implement Sorting Networks with HierarQcal",
+        "project": "hierarqcal",
+        "value": 150
+      }
+    ],
+    "num_projects": 4,
+    "total_value": 575
+  },
+  {
+    "username": "freifrauvonbleifrei",
+    "bounties": [
+      {
+        "url": "https://github.com/NVIDIA/cuda-quantum/issues/1638",
+        "title": "Enable emitting circuit diagrams for unitary quantum kernels in LaTeX",
+        "project": "cuda-quantum",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "AVDiv",
+    "bounties": [
+      {
+        "url": "https://github.com/unitaryfund/metriq-client/issues/119",
+        "title": "Update to pyproject.toml",
+        "project": "metriq-app",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "NnguyenHTommy",
+    "bounties": [
+      {
+        "url": "https://github.com/unitaryfund/mitiq/issues/2354",
+        "title": "Qiskit Quantum Fourier Transform (QFT) circuits error out during conversion",
+        "project": "mitiq",
+        "value": 80
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 80
+  },
+  {
+    "username": "EmilianoG-byte",
+    "bounties": [
+      {
+        "url": "https://github.com/unitaryfund/mitiq/issues/2346",
+        "title": "In Pauli Twirling: allow user to pass a `noise_gate` or similar to simulate noise in between the twirled gates and CNOT / CZ gates.",
+        "project": "mitiq",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "JuanitaCathy",
+    "bounties": [
+      {
+        "url": "https://github.com/Quantum-Universal-Education/Quantum-Universal-Education.github.io/issues/24",
+        "title": "Quantum Software and Games  [unitaryhack]",
+        "project": "quantum-universal-education.github.io",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "GubioGL",
+    "bounties": [
+      {
+        "url": "https://github.com/Quantum-Universal-Education/Quantum-Universal-Education.github.io/issues/16",
+        "title": "Building a Quantum Computer  [unitaryhack] ",
+        "project": "quantum-universal-education.github.io",
+        "value": 50
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 50
+  },
+  {
+    "username": "tnemoz",
+    "bounties": [
+      {
+        "url": "https://github.com/vprusso/toqito/issues/519",
+        "title": "Add unambiguous discrimination strategy to state distinguishability and state exclusion",
+        "project": "toqito",
+        "value": 80
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 80
+  },
+  {
+    "username": "Roshan-Thomas",
+    "bounties": [
+      {
+        "url": "https://github.com/vprusso/toqito/issues/401",
+        "title": "References in tutorials",
+        "project": "toqito",
+        "value": 80
+      },
+      {
+        "url": "https://github.com/scqubits/scqubits/issues/222",
+        "title": "Adding code documentation",
+        "project": "scqubits",
+        "value": 25
+      },
+      {
+        "url": "https://github.com/TeamGraphix/graphix/issues/137",
+        "title": "Tutorial and documentation style upgrade",
+        "project": "graphix",
+        "value": 130
+      }
+    ],
+    "num_projects": 3,
+    "total_value": 235
+  },
+  {
+    "username": "EuGig",
+    "bounties": [
+      {
+        "url": "https://github.com/amazon-braket/amazon-braket-default-simulator-python/issues/240",
+        "title": "AttributeError: 'ArrayLiteral' object has no attribute 'value'.",
+        "project": "amazon-braket-default-simulator-python",
+        "value": 70
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 70
+  },
+  {
+    "username": "Tarun-Kumar07",
+    "bounties": [
+      {
+        "url": "https://github.com/amazon-braket/amazon-braket-sdk-python/issues/603",
+        "title": "Error when FreeParameters are named QASM types ",
+        "project": "amazon-braket-sdk-python",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/PennyLaneAI/pennylane/issues/5644",
+        "title": "Improve operator support for new `assert_equal` function: Group 1",
+        "project": "pennylane",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/PennyLaneAI/pennylane/issues/5648",
+        "title": "Improve operator support for new `assert_equal` function: Group 2",
+        "project": "pennylane",
+        "value": 75
+      },
+      {
+        "url": "https://github.com/PennyLaneAI/pennylane/issues/5649",
+        "title": "Add a QutritChannel operation",
+        "project": "pennylane",
+        "value": 125
+      }
+    ],
+    "num_projects": 2,
+    "total_value": 375
+  },
+  {
+    "username": "LorenzoFioroni",
+    "bounties": [
+      {
+        "url": "https://github.com/qutip/QuantumToolbox.jl/issues/81",
+        "title": "Add a the iterative solvers and eigensolver for `steadystate`",
+        "project": "quantumtoolbox.jl",
+        "value": 125
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 125
+  },
+  {
+    "username": "samu-sys",
+    "bounties": [
+      {
+        "url": "https://github.com/qutip/QuantumToolbox.jl/issues/82",
+        "title": "Improve the Floquet solver, with the possibility to get also the time-dependent components",
+        "project": "quantumtoolbox.jl",
+        "value": 125
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 125
+  },
+  {
+    "username": "ilkclord",
+    "bounties": [
+      {
+        "url": "https://github.com/qutip/QuantumToolbox.jl/issues/84",
+        "title": "ODE-based `steadystate` solving method",
+        "project": "quantumtoolbox.jl",
+        "value": 125
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 125
+  },
+  {
+    "username": "aarontrowbridge",
+    "bounties": [
+      {
+        "url": "https://github.com/qutip/QuantumToolbox.jl/issues/95",
+        "title": "Support `permute` to re-order the tensor (Kronecker) product",
+        "project": "quantumtoolbox.jl",
+        "value": 125
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 125
+  },
+  {
+    "username": "SoshunNaito",
+    "bounties": [
+      {
+        "url": "https://github.com/bqskit/bqskit/issues/224",
+        "title": "Subgraph Isomorphism Checks",
+        "project": "bqskit",
+        "value": 250
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 250
+  },
+  {
+    "username": "Piwakk",
+    "bounties": [
+      {
+        "url": "https://github.com/qua-platform/qua-qsim/issues/4",
+        "title": "Create frontend interface",
+        "project": "qua-qsim",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/qua-platform/qua-qsim/issues/5",
+        "title": "Live conversion from QUA to Qiskit simulations",
+        "project": "qua-qsim",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 200
+  },
+  {
+    "username": "MZuhairKhan",
+    "bounties": [
+      {
+        "url": "https://github.com/qosf/qosf.org/issues/28",
+        "title": "Automate the list of contributors",
+        "project": "qosf.org",
+        "value": 30
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 30
+  },
+  {
+    "username": "MashAliK",
+    "bounties": [
+      {
+        "url": "https://github.com/PennyLaneAI/pennylane/issues/5646",
+        "title": "Improve measurement support in from_qasm",
+        "project": "pennylane",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  },
+  {
+    "username": "dhanaabhirajk",
+    "bounties": [
+      {
+        "url": "https://github.com/qBraid/qBraid/issues/626",
+        "title": "Convert OpenQASM 3 program to specified basis gate set",
+        "project": "qbraid",
+        "value": 150
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 150
+  },
+  {
+    "username": "ahkatlio",
+    "bounties": [
+      {
+        "url": "https://github.com/scqubits/scqubits/issues/222",
+        "title": "Adding code documentation",
+        "project": "scqubits",
+        "value": 25
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 25
+  },
+  {
+    "username": "ejthomas",
+    "bounties": [
+      {
+        "url": "https://github.com/qBraid/qbraid-qir/issues/67",
+        "title": "Support loop statements in `qasm3` converter",
+        "project": "qbraid-qir",
+        "value": 150
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 150
+  },
+  {
+    "username": "Barnald",
+    "bounties": [
+      {
+        "url": "https://github.com/TeamGraphix/graphix/issues/136",
+        "title": "Application of tensor-network MBQC simulation",
+        "project": "graphix",
+        "value": 55
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 55
+  },
+  {
+    "username": "burlemarxiste",
+    "bounties": [
+      {
+        "url": "https://github.com/Quandela/Perceval/issues/399",
+        "title": "QASM to linear optics circuit converter",
+        "project": "perceval",
+        "value": 100
+      },
+      {
+        "url": "https://github.com/Quandela/Perceval/issues/207",
+        "title": "Heralds out of their box",
+        "project": "perceval",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 200
+  },
+  {
+    "username": "huyenemma",
+    "bounties": [
+      {
+        "url": "https://github.com/ionq-samples/Ion-Q-Thruster/issues/3",
+        "title": "Issue 2: Add Trapped-Ion-Specific Optimizations to Custom Optimizer",
+        "project": "ion-q-thruster",
+        "value": 100
+      }
+    ],
+    "num_projects": 1,
+    "total_value": 100
+  }
+]

--- a/src/hackers.njk
+++ b/src/hackers.njk
@@ -1,6 +1,6 @@
 ---
 pagination:
-  data: hackers
+  data: hackersByYear
   size: 1
   alias: hacker
 permalink: "hackers/{{ hacker.username | slugify }}/"
@@ -11,18 +11,21 @@ layout: base.njk
   <h1><code>{{ hacker.username }}</code></h1>
   <hr>
   <p>
-    {% if hacker.bounties | length > 1 %}
-      <code>{{ hacker.username }}</code> has claimed ${{ hacker.total_value }} by closing {{ hacker.bounties | length }} issues across {{ hacker.num_projects }} projects!
+    {% if hacker.total_bounties > 1 %}
+      <code>{{ hacker.username }}</code> has claimed ${{ hacker.total_value }} by closing {{ hacker.total_bounties }} issues across {{ hacker.num_projects }} projects!
     {% else %}
-      <code>{{ hacker.username }}</code> has claimed ${{ hacker.total_value }} by closing {{ hacker.bounties | length }} issue across {{ hacker.num_projects }} projects!
+      <code>{{ hacker.username }}</code> has claimed ${{ hacker.total_value }} by closing {{ hacker.total_bounties }} issue across {{ hacker.num_projects }} projects!
     {% endif %}
   </p>
   <h2>Bounties Completed</h2>
-  <ul>
-    {% for bounty in hacker.bounties %}
-      <li><code>{{ bounty.project }}</code>: <a href={{ bounty.url }}>{% mdRender %}{{ bounty.title }}{% endmdRender %}</a></li>
-    {% endfor %}
-  </ul>
+  {% for hack_year in hacker.years %}
+    <h3>{{ hack_year.year }}</h3>
+    <ul>
+      {% for bounty in hack_year.bounties %}
+        <li><code>{{ bounty.project }}</code>: <a href={{ bounty.url }}>{% mdRender %}{{ bounty.title }}{% endmdRender %}</a></li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
   <br>
   <p>
     Check out more great work from <code>{{ hacker.username }}</code> over on their GitHub account: <a href="https://github.com/{{ hacker.username }}">https://github.com/{{ hacker.username }}</a>!


### PR DESCRIPTION
Closes #52

## Summary
- add 2023 and 2024 hacker data snapshots
- merge current and historical hacker records by username for hacker profile pagination
- render completed bounties grouped by unitaryHACK year

## Validation
- `node -e "const hackers = require('./src/_data/hackersByYear')(); console.log(hackers.length); console.log(hackers.find((h) => h.years.length > 1).username);"`
- `npm run build`
- verified `_site/hackers/wingcode/index.html` contains both `2024` and `2023` bounty sections