### PR TITLE
Document year subdomain archive process

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,35 @@ Here are some basic local setup steps to get you started:
 **`npm run build`**: Generate minified production build
 
 Check out the Eleventy [command line usage docs](https://www.11ty.dev/docs/usage/) for more options.
+
+## 🗄️ Archiving an edition on a year subdomain
+
+When a new unitaryHACK website replaces the current production site, keep the previous
+edition available on a year-specific subdomain such as `2025.unitaryhack.dev`.
+
+1. Decide the archive year and target hostname, for example `2025.unitaryhack.dev`.
+2. Make sure the old edition builds as a standalone site:
+   - run `npm ci`
+   - run `INCLUDE_CNAME=false SITE_URL=https://2025.unitaryhack.dev npm run build`
+   - open `_site/index.html` or serve `_site/` locally and check that internal links and assets work.
+3. Deploy the generated `_site/` directory for the archived edition to its own static hosting target.
+   GitHub Pages is preferred when possible because it keeps the archive in GitHub, but Netlify is
+   acceptable if the edition still depends on Netlify-specific configuration.
+4. Point the DNS record for the year subdomain at the archive host:
+   - for GitHub Pages, follow GitHub's custom-domain instructions and add the required `CNAME`
+     or `A`/`AAAA` records for the archive target;
+   - for Netlify, add the year subdomain to the archived site and follow Netlify's DNS target.
+5. Do not keep the production `src/CNAME` value in archive builds unless that archive host is
+   meant to serve `unitaryhack.dev`. The current deployment workflow uses `INCLUDE_CNAME=false`
+   for non-production GitHub Pages builds for this reason.
+6. Update the current year's README history list so the archived edition is linked alongside
+   previous years.
+7. Update any recap or announcement posts that still point at `unitaryhack.dev` for the archived
+   year. For the 2025 move, this includes the 2025 recap post linked from issue
+   [`#60`](https://github.com/unitaryfoundation/unitaryhack/issues/60).
+8. Verify the archive after DNS propagation:
+   - `https://<year>.unitaryhack.dev/` loads over HTTPS;
+   - major pages such as `/projects/`, `/bounties/`, `/leaderboard/`, and `/hackers/<username>/`
+     return `200`;
+   - images, CSS, JavaScript, and canonical links point at the archive hostname instead of the
+     new production site.


### PR DESCRIPTION
Closes #61

## Summary
- add README instructions for archiving a previous unitaryHACK edition on a year subdomain
- document build flags, hosting/DNS steps, CNAME handling, recap link updates, and post-DNS verification

## Validation
- `git diff --check`
- documentation-only change