### PR TITLE
Fix mobile menu horizontal overflow

### DIFF
--- a/src/assets/scss/components/drawer.scss
+++ b/src/assets/scss/components/drawer.scss
@@ -65,6 +65,7 @@
 }
 
 .drawer__wrapper {
+  box-sizing: border-box;
   position: fixed;
   top: 0;
   right: 0;

--- a/src/assets/scss/components/site-footer.scss
+++ b/src/assets/scss/components/site-footer.scss
@@ -1,4 +1,5 @@
 .site-footer {
+  box-sizing: border-box;
   width: 100%;
   max-width: var(--site-width);
   margin: auto auto 0;


### PR DESCRIPTION
## Summary
- keep the site footer from widening mobile pages beyond the viewport
- include the drawer border inside the fixed drawer width so the panel stays within the viewport

Fixes #46.

## Testing
- npm run build
- git diff --check
- local mobile viewport check at `/bounties/`: before opening the menu, `scrollWidth == clientWidth`; after tapping Menu, the drawer wrapper is fully within the 390px viewport and nav links are visible
- checked browser console for runtime errors: none